### PR TITLE
Add support for Bitbucket Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `get_client` method and `url` field in `BitbucketCredentials` - [#7](https://github.com/PrefectHQ/prefect-bitbucket/pull/7/)
+- support to log into Bitbucket Server with `token` and `username` [#11](https://github.com/PrefectHQ/prefect-bitbucket/pull/11/)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `get_client` method and `url` field in `BitbucketCredentials` - [#7](https://github.com/PrefectHQ/prefect-bitbucket/pull/7/)
-- support to log into Bitbucket Server with `token` and `username` [#11](https://github.com/PrefectHQ/prefect-bitbucket/pull/11/)
+- support to log into Bitbucket Server with `token` and `username` - [#11](https://github.com/PrefectHQ/prefect-bitbucket/pull/11/)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,9 @@ private_bitbucket_block = BitBucketRepository(
 private_bitbucket_block.save(name="my-private-bitbucket-block")
 ```
 
-## Differences between Bitbucket Server and Bitbucket Cloud
+!!! info "Differences between Bitbucket Server and Bitbucket Cloud"
 
-- For Bitbucket Cloud, only set the token.
-- For Bitbucket Server, set token and username. 
+For Bitbucket Cloud, only set the `token` to authenticate. For Bitbucket Server, set both the `token` and the `username`.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ private_bitbucket_block.save(name="my-private-bitbucket-block")
 
 !!! info "Differences between Bitbucket Server and Bitbucket Cloud"
 
-For Bitbucket Cloud, only set the `token` to authenticate. For Bitbucket Server, set both the `token` and the `username`.
+    For Bitbucket Cloud, only set the `token` to authenticate. For Bitbucket Server, set both the `token` and the `username`.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ private_bitbucket_block = BitBucketRepository(
 private_bitbucket_block.save(name="my-private-bitbucket-block")
 ```
 
+## Differences between Bitbucket Server and Bitbucket Cloud
+
+- For Bitbucket Cloud, only set the token.
+- For Bitbucket Server, set token and username. 
+
 ## Resources
 
 If you encounter any bugs while using `prefect-bitbucket`, feel free to open an issue in the [prefect-bitbucket](https://github.com/PrefectHQ/prefect-bitbucket) repository.

--- a/prefect_bitbucket/repository.py
+++ b/prefect_bitbucket/repository.py
@@ -104,15 +104,21 @@ class BitBucketRepository(ReadableDeploymentStorage):
     def _create_repo_url(self) -> str:
         """Format the URL provided to the `git clone` command.
 
-        For private repos:
+        For private repos in the cloud:
         https://x-token-auth:<access-token>@bitbucket.org/<user>/<repo>.git
+        For private repos with a local bitbucket server:
+        https://<username>:<access-token>@<server>/scm/<project>/<repo>.git
+
         All other repos should be the same as `self.repository`.
         """
         url_components = urlparse(self.repository)
         if url_components.scheme == "https" and self.bitbucket_credentials is not None:
             token = self.bitbucket_credentials.token.get_secret_value()
+            username = self.bitbucket_credentials.username
+            if username is None:
+                username = "x-token-auth"
             updated_components = url_components._replace(
-                netloc=f"x-token-auth:{token}@{url_components.netloc}"
+                netloc=f"{username}:{token}@{url_components.netloc}"
             )
             full_url = urlunparse(updated_components)
         else:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -144,6 +144,32 @@ class TestBitBucketRepository:
         ]
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
+    async def test_token_with_username_added_correctly_from_credential(self, monkeypatch):
+        """Ensure that the repo url is in the format `https://username:token@url`."""  # noqa: E501
+
+        class p:
+            returncode = 0
+
+        mock = AsyncMock(return_value=p())
+        monkeypatch.setattr(prefect_bitbucket.repository, "run_process", mock)
+        credential = "XYZ"
+        username = "ABC"
+        repo = "https://bitbucket.org/PrefectHQ/prefect.git"
+        b = BitBucketRepository(
+            repository=repo,
+            bitbucket_credentials=BitBucketCredentials(token=SecretStr(credential), username=username),
+        )
+        await b.get_directory()
+        assert mock.await_count == 1
+        expected_cmd = [
+            "git",
+            "clone",
+            f"https://{username}:{credential}@bitbucket.org/PrefectHQ/prefect.git",
+            "--depth",
+            "1",
+        ]
+        assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd        
+        
     async def test_ssh_fails_with_credential(self, monkeypatch):
         """Ensure that credentials cannot be passed in if the URL is not in the HTTPS
         format.

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -144,7 +144,9 @@ class TestBitBucketRepository:
         ]
         assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
 
-    async def test_token_with_username_added_correctly_from_credential(self, monkeypatch):
+    async def test_token_with_username_added_correctly_from_credential(
+        self, monkeypatch
+    ):
         """Ensure that the repo url is in the format `https://username:token@url`."""  # noqa: E501
 
         class p:
@@ -157,7 +159,9 @@ class TestBitBucketRepository:
         repo = "https://bitbucket.org/PrefectHQ/prefect.git"
         b = BitBucketRepository(
             repository=repo,
-            bitbucket_credentials=BitBucketCredentials(token=SecretStr(credential), username=username),
+            bitbucket_credentials=BitBucketCredentials(
+                token=SecretStr(credential), username=username
+            ),
         )
         await b.get_directory()
         assert mock.await_count == 1
@@ -168,8 +172,8 @@ class TestBitBucketRepository:
             "--depth",
             "1",
         ]
-        assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd        
-        
+        assert mock.await_args[0][0][: len(expected_cmd)] == expected_cmd
+
     async def test_ssh_fails_with_credential(self, monkeypatch):
         """Ensure that credentials cannot be passed in if the URL is not in the HTTPS
         format.


### PR DESCRIPTION
Logging into Bitbucket cloud requires:

`"https://x-token-auth:{credential}@bitbucket.org/PrefectHQ/prefect.git"`

Logging into Bitbucket Server requires, _even if {credential} is the token and not the password !!_ 

`"https://{username}:{credential}@bitbucketserver.com/scm/projectname/teamsinspace.git"`

This behavior is documented here: https://confluence.atlassian.com/bitbucketserver/http-access-tokens-939515499.html and different to the cloud where a username is not allowed with a token and x-token-auth shall be used instead.

This pull request is to add support for Bitbucket Server. 
Closes #10 

Hope I've done all that is needed (sorry if not, i'm new here)
Sebastian


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-bitbucket/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-bitbucket/blob/main/CHANGELOG.md)
