### PR TITLE
 Add `BitBucketCredentials` placeholder text for token field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-
+- Add placeholder text to `BitBucketCredentials` token field in UI - [#23](
+    https://github.com/PrefectHQ/prefect-bitbucket/pull/23/)
 ### Changed
 
 ### Deprecated

--- a/prefect_bitbucket/credentials.py
+++ b/prefect_bitbucket/credentials.py
@@ -48,6 +48,7 @@ class BitBucketCredentials(CredentialsBlock):
         description=(
             "A BitBucket Personal Access Token - required for private repositories."
         ),
+        example="x-token-auth:my-token",
     )
     username: Optional[str] = Field(
         default=None,


### PR DESCRIPTION
Part of closing https://github.com/PrefectHQ/prefect/issues/10468

This PR adds placeholder text in the UI so that users creating `BitBucketCredentials` blocks in the UI will be guided toward formatting their blocks with the `x-token-auth` header.

#### Screenshot
<img width="598" alt="Screenshot 2023-08-25 at 10 39 55 AM" src="https://github.com/PrefectHQ/prefect-bitbucket/assets/42048900/694709b4-0264-4439-81ac-d0e3f43baa7b">

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-bitbucket/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-bitbucket/blob/main/CHANGELOG.md)
