### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_bitbucket/credentials.py
+++ b/prefect_bitbucket/credentials.py
@@ -4,7 +4,12 @@ from enum import Enum
 from typing import Optional, Union
 
 from prefect.blocks.abstract import CredentialsBlock
-from pydantic import Field, SecretStr, validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr, validator
+else:
+    from pydantic import Field, SecretStr, validator
 
 try:
     from atlassian.bitbucket import Bitbucket, Cloud

--- a/prefect_bitbucket/repository.py
+++ b/prefect_bitbucket/repository.py
@@ -46,7 +46,12 @@ from prefect.exceptions import InvalidRepositoryURLError
 from prefect.filesystems import ReadableDeploymentStorage
 from prefect.utilities.asyncutils import sync_compatible
 from prefect.utilities.processutils import run_process
-from pydantic import Field, validator
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, validator
+else:
+    from pydantic import Field, validator
 
 from prefect_bitbucket.credentials import BitBucketCredentials
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -6,7 +6,12 @@ from typing import Set, Tuple
 import pytest
 from prefect.exceptions import InvalidRepositoryURLError
 from prefect.testing.utilities import AsyncMock
-from pydantic import SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import SecretStr
+else:
+    from pydantic import SecretStr
 
 import prefect_bitbucket
 from prefect_bitbucket.credentials import BitBucketCredentials


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.