### PR TITLE
avoid `3.41.5-3.41.8` (inclusive)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 prefect>=2.13.5
-atlassian-python-api>=3.32.1
+atlassian-python-api>=3.32.1,!=3.41.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 prefect>=2.13.5
-atlassian-python-api>=3.32.1,!=3.41.5
+atlassian-python-api>=3.32.1,!=3.41.5,!=3.41.6,!=3.41.7,!=3.41.8


### PR DESCRIPTION
it seems that `atlassian-python-api` had a [release `3.41.5` that had a broken import](https://github.com/atlassian-api/atlassian-python-api/issues/1295), and that [subsequent releases](https://github.com/atlassian-api/atlassian-python-api/issues/1301) (may) have performance issues